### PR TITLE
Use edge v0.7.14 which fixes unicode issues that affect azurecache values

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "dependencies": {
-    "edge": "0.7.13"
+    "edge": "0.7.14"
   },
   "homepage": "https://github.com/tjanczuk/azurecache",
   "repository": {


### PR DESCRIPTION
Sorry, I already did the request (closed it and now open it again), but I got confused with https://github.com/projectkudu/kudu/issues/914 So here we go again... ;-)

With the edge 0.7.13 binding I there were problems with strings like "Je suis français." Same holds true for objects that contain such strings. Just tested the fix on Azure and works great for me.

Thanks, Philip
